### PR TITLE
Add V=1 as an abbreviation of VERBOSE=1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ CFLAGS += -no-pie
 endif
 
 # Control the build verbosity
+# `make V=1` is equal to `make VERBOSE=1`
+ifeq ("$(origin V)", "command line")
+    VERBOSE = $(V)
+endif
 ifeq ("$(VERBOSE)","1")
     Q :=
     VECHO = @true


### PR DESCRIPTION
Since `make V=1` is much more widespread than `make VERBOSE=1`,
add it and keep `VERBOSE` alive if someone really needs it.