### PR TITLE
Add private data into Token struct

### DIFF
--- a/lexer.c
+++ b/lexer.c
@@ -209,7 +209,7 @@ static Token *read_token_int(void)
 
 bool is_punct(Token *tok, int c)
 {
-    return tok && (tok->type == TTYPE_PUNCT) && ((int) tok->priv == c);
+    return tok && (get_ttype(tok) == TTYPE_PUNCT) && (get_punct(tok) == c);
 }
 
 void unget_token(Token *tok)

--- a/lexer.c
+++ b/lexer.c
@@ -3,45 +3,19 @@
 #include <stdlib.h>
 #include "mzcc.h"
 
+#define make_strtok(x) make_token(TTYPE_STRING, (uintptr_t) get_cstring(x))
+#define make_ident(x) make_token(TTYPE_IDENT, (uintptr_t) get_cstring(x))
+#define make_punct(x) make_token(TTYPE_PUNCT, (uintptr_t) (x))
+#define make_number(x) make_token(TTYPE_NUMBER, (uintptr_t) (x))
+#define make_char(x) make_token(TTYPE_CHAR, (uintptr_t) (x))
+
 static Token *ungotten = NULL;
 
-static Token *make_ident(String *s)
+static Token *make_token(enum TokenType type, uintptr_t data)
 {
     Token *r = malloc(sizeof(Token));
-    r->type = TTYPE_IDENT;
-    r->sval = get_cstring(s);
-    return r;
-}
-
-static Token *make_strtok(String *s)
-{
-    Token *r = malloc(sizeof(Token));
-    r->type = TTYPE_STRING;
-    r->sval = get_cstring(s);
-    return r;
-}
-
-static Token *make_punct(int punct)
-{
-    Token *r = malloc(sizeof(Token));
-    r->type = TTYPE_PUNCT;
-    r->punct = punct;
-    return r;
-}
-
-static Token *make_number(char *s)
-{
-    Token *r = malloc(sizeof(Token));
-    r->type = TTYPE_NUMBER;
-    r->sval = s;
-    return r;
-}
-
-static Token *make_char(char c)
-{
-    Token *r = malloc(sizeof(Token));
-    r->type = TTYPE_CHAR;
-    r->c = c;
+    r->type = type;
+    r->priv = data;
     return r;
 }
 
@@ -235,7 +209,7 @@ static Token *read_token_int(void)
 
 bool is_punct(Token *tok, int c)
 {
-    return tok && (tok->type == TTYPE_PUNCT) && (tok->punct == c);
+    return tok && (tok->type == TTYPE_PUNCT) && ((int) tok->priv == c);
 }
 
 void unget_token(Token *tok)

--- a/mzcc.h
+++ b/mzcc.h
@@ -2,11 +2,12 @@
 #define MAZUCC_H
 
 #include <stdbool.h>
+#include <stdint.h>
 #include "dict.h"
 #include "list.h"
 #include "util.h"
 
-enum {
+enum TokenType {
     TTYPE_IDENT,
     TTYPE_PUNCT,
     TTYPE_NUMBER,
@@ -16,11 +17,7 @@ enum {
 
 typedef struct {
     int type;
-    union {
-        char *sval;
-        int punct;
-        char c;
-    };
+    uintptr_t priv;
 } Token;
 
 enum {

--- a/mzcc.h
+++ b/mzcc.h
@@ -168,6 +168,30 @@ extern void unget_token(Token *tok);
 extern Token *peek_token(void);
 extern Token *read_token(void);
 
+#define get_priv(tok, type)                                         \
+({                                                                  \
+        assert(__builtin_types_compatible_p(typeof(tok), Token *)); \
+        ((type) tok->priv);                                         \
+})
+
+#define get_ttype(tok)                                              \
+({                                                                  \
+        assert(__builtin_types_compatible_p(typeof(tok), Token *)); \
+        (tok->type);                                                \
+})
+
+#define get_token(tok, ttype, priv_type)                            \
+({                                                                  \
+        assert(get_ttype(tok) == ttype);                            \
+        get_priv(tok, priv_type);                                   \
+})
+
+#define get_char(tok) get_token(tok, TTYPE_CHAR, char)
+#define get_strtok(tok) get_token(tok, TTYPE_STRING, char *)
+#define get_ident(tok) get_token(tok, TTYPE_IDENT, char *)
+#define get_number(tok) get_token(tok, TTYPE_NUMBER, char *)
+#define get_punct(tok) get_token(tok, TTYPE_PUNCT, int)
+
 /* parser.c */
 extern List *strings;
 extern List *flonums;

--- a/verbose.c
+++ b/verbose.c
@@ -215,24 +215,24 @@ char *token_to_string(Token *tok)
     if (!tok)
         return "(null)";
     String *s = make_string();
-    switch (tok->type) {
+    switch (get_ttype(tok)) {
     case TTYPE_IDENT:
-        return (char *) tok->priv;
+        return get_ident(tok);
     case TTYPE_PUNCT:
         if (is_punct(tok, PUNCT_EQ))
             string_appendf(s, "==");
         else
-            string_appendf(s, "%c", (char) tok->priv);
+            string_appendf(s, "%c", get_punct(tok));
         return get_cstring(s);
     case TTYPE_CHAR:
-        string_append(s, (char) tok->priv);
+        string_append(s, get_char(tok));
         return get_cstring(s);
     case TTYPE_NUMBER:
-        return (char *) tok->priv;
+        return get_number(tok);
     case TTYPE_STRING:
-        string_appendf(s, "\"%s\"", (char *) tok->priv);
+        string_appendf(s, "\"%s\"", get_strtok(tok));
         return get_cstring(s);
     }
-    error("internal error: unknown token type: %d", tok->type);
+    error("internal error: unknown token type: %d", get_ttype(tok));
     return NULL; /* non-reachable */
 }

--- a/verbose.c
+++ b/verbose.c
@@ -217,20 +217,20 @@ char *token_to_string(Token *tok)
     String *s = make_string();
     switch (tok->type) {
     case TTYPE_IDENT:
-        return tok->sval;
+        return (char *) tok->priv;
     case TTYPE_PUNCT:
         if (is_punct(tok, PUNCT_EQ))
             string_appendf(s, "==");
         else
-            string_appendf(s, "%c", tok->c);
+            string_appendf(s, "%c", (char) tok->priv);
         return get_cstring(s);
     case TTYPE_CHAR:
-        string_append(s, tok->c);
+        string_append(s, (char) tok->priv);
         return get_cstring(s);
     case TTYPE_NUMBER:
-        return tok->sval;
+        return (char *) tok->priv;
     case TTYPE_STRING:
-        string_appendf(s, "\"%s\"", tok->sval);
+        string_appendf(s, "\"%s\"", (char *) tok->priv);
         return get_cstring(s);
     }
     error("internal error: unknown token type: %d", tok->type);


### PR DESCRIPTION
The definition of make_* functions are similar, so consolidate
these functions to a single `make_token()` and use define to keep
origin make_* function exist for readability.

To achieve this goal, we have to merge the union inside `struct Token`.
Each of the elements in the union is relative to one or more Token enum types,
but actully they can be merged to a single private data.

After that, add helper function to avoid exposing private data.
