### PR TITLE
Deal with memory leak caused by string and token

### DIFF
--- a/dict.h
+++ b/dict.h
@@ -28,8 +28,8 @@ static inline void *make_dict(void *parent)
 static inline void *dict_get(Dict *dict, char *key)
 {
     for (; dict; dict = dict->parent) {
-        for (Iter *i = list_iter(dict->list); !iter_end(i);) {
-            DictEntry *e = iter_next(i);
+        for (Iter i = list_iter(dict->list); !iter_end(i);) {
+            DictEntry *e = iter_next(&i);
             if (!strcmp(key, e->key))
                 return e->val;
         }
@@ -49,8 +49,8 @@ static inline List *dict_keys(Dict *dict)
 {
     List *r = make_list();
     for (; dict; dict = dict->parent)
-        for (Iter *i = list_iter(dict->list); !iter_end(i);)
-            list_push(r, ((DictEntry *) iter_next(i))->key);
+        for (Iter i = list_iter(dict->list); !iter_end(i);)
+            list_push(r, ((DictEntry *) iter_next(&i))->key);
     return r;
 }
 
@@ -58,8 +58,8 @@ static inline List *dict_values(Dict *dict)
 {
     List *r = make_list();
     for (; dict; dict = dict->parent)
-        for (Iter *i = list_iter(dict->list); !iter_end(i);)
-            list_push(r, ((DictEntry *) iter_next(i))->val);
+        for (Iter i = list_iter(dict->list); !iter_end(i);)
+            list_push(r, ((DictEntry *) iter_next(&i))->val);
     return r;
 }
 

--- a/lexer.c
+++ b/lexer.c
@@ -34,15 +34,15 @@ static int getc_nonspace(void)
 
 static Token read_number(char c)
 {
-    String *s = make_string();
-    string_append(s, c);
+    String s = make_string();
+    string_append(&s, c);
     while (1) {
         int c = getc(stdin);
         if (!isdigit(c) && !isalpha(c) && c != '.') {
             ungetc(c, stdin);
             return make_number(get_cstring(s));
         }
-        string_append(s, c);
+        string_append(&s, c);
     }
 }
 
@@ -69,7 +69,7 @@ err:
 
 static Token read_string(void)
 {
-    String *s = make_string();
+    String s = make_string();
     while (1) {
         int c = getc(stdin);
         if (c == EOF)
@@ -90,19 +90,19 @@ static Token read_string(void)
                 error("Unknown quote: %c", c);
             }
         }
-        string_append(s, c);
+        string_append(&s, c);
     }
     return make_strtok(s);
 }
 
 static Token read_ident(char c)
 {
-    String *s = make_string();
-    string_append(s, c);
+    String s = make_string();
+    string_append(&s, c);
     while (1) {
         int c2 = getc(stdin);
         if (isalnum(c2) || c2 == '_') {
-            string_append(s, c2);
+            string_append(&s, c2);
         } else {
             ungetc(c2, stdin);
             return make_ident(s);

--- a/list.h
+++ b/list.h
@@ -109,17 +109,13 @@ static inline int list_len(List *list)
     return list->len;
 }
 
-static inline void iter_next_and_free(Iter *iter)
-{
-    ListNode *now = iter->ptr;
-    iter->ptr = now->next;
-    free(now->elem);
-    free(now);
-}
-
 static inline void list_free(List *list)
 {
-    for (Iter i = list_iter(list); !iter_end(i);)
-        iter_next_and_free(&i);
+    for (Iter i = list_iter(list); !iter_end(i);) {
+        ListNode *now = i.ptr;
+        i.ptr = now->next;
+        free(now->elem);
+        free(now);
+    }
 }
 #endif /* MAZUCC_LIST_H */

--- a/list.h
+++ b/list.h
@@ -75,16 +75,16 @@ static void list_unshift(List *list, void *elem)
     list->len++;
 }
 
-static inline Iter *list_iter(void *ptr)
+static inline Iter list_iter(void *ptr)
 {
-    Iter *r = malloc(sizeof(Iter));
-    r->ptr = ((List *) ptr)->head;
-    return r;
+    return (Iter){
+        .ptr = ((List *) ptr)->head,
+    };
 }
 
-static inline bool iter_end(Iter *iter)
+static inline bool iter_end(const Iter iter)
 {
-    return !iter->ptr;
+    return !iter.ptr;
 }
 
 static inline void *iter_next(Iter *iter)
@@ -99,8 +99,8 @@ static inline void *iter_next(Iter *iter)
 static inline List *list_reverse(List *list)
 {
     List *r = make_list();
-    for (Iter *i = list_iter(list); !iter_end(i);)
-        list_unshift(r, iter_next(i));
+    for (Iter i = list_iter(list); !iter_end(i);)
+        list_unshift(r, iter_next(&i));
     return r;
 }
 

--- a/list.h
+++ b/list.h
@@ -109,4 +109,17 @@ static inline int list_len(List *list)
     return list->len;
 }
 
+static inline void iter_next_and_free(Iter *iter)
+{
+    ListNode *now = iter->ptr;
+    iter->ptr = now->next;
+    free(now->elem);
+    free(now);
+}
+
+static inline void list_free(List *list)
+{
+    for (Iter i = list_iter(list); !iter_end(i);)
+        iter_next_and_free(&i);
+}
 #endif /* MAZUCC_LIST_H */

--- a/main.c
+++ b/main.c
@@ -10,8 +10,8 @@ int main(int argc, char **argv)
     if (!dump_ast)
         emit_data_section();
 
-    for (Iter *i = list_iter(toplevels); !iter_end(i);) {
-        Ast *v = iter_next(i);
+    for (Iter i = list_iter(toplevels); !iter_end(i);) {
+        Ast *v = iter_next(&i);
         if (dump_ast)
             printf("%s", ast_to_string(v));
         else

--- a/main.c
+++ b/main.c
@@ -17,5 +17,6 @@ int main(int argc, char **argv)
         else
             emit_toplevel(v);
     }
+    list_free(cstrings);
     return 0;
 }

--- a/mzcc.h
+++ b/mzcc.h
@@ -8,6 +8,7 @@
 #include "util.h"
 
 enum TokenType {
+    TTYPE_NULL,
     TTYPE_IDENT,
     TTYPE_PUNCT,
     TTYPE_NUMBER,
@@ -160,26 +161,26 @@ typedef struct __Ast {
 } Ast;
 
 /* verbose.c */
-extern char *token_to_string(Token *tok);
+extern char *token_to_string(const Token tok);
 extern char *ast_to_string(Ast *ast);
 extern char *ctype_to_string(Ctype *ctype);
 
 /* lexer.c */
-extern bool is_punct(Token *tok, int c);
-extern void unget_token(Token *tok);
-extern Token *peek_token(void);
-extern Token *read_token(void);
+extern bool is_punct(const Token tok, int c);
+extern void unget_token(const Token tok);
+extern Token peek_token(void);
+extern Token read_token(void);
 
-#define get_priv(tok, type)                                         \
-    ({                                                              \
-        assert(__builtin_types_compatible_p(typeof(tok), Token *)); \
-        ((type) tok->priv);                                         \
+#define get_priv(tok, type)                                       \
+    ({                                                            \
+        assert(__builtin_types_compatible_p(typeof(tok), Token)); \
+        ((type) tok.priv);                                        \
     })
 
-#define get_ttype(tok)                                              \
-    ({                                                              \
-        assert(__builtin_types_compatible_p(typeof(tok), Token *)); \
-        (tok->type);                                                \
+#define get_ttype(tok)                                            \
+    ({                                                            \
+        assert(__builtin_types_compatible_p(typeof(tok), Token)); \
+        (tok.type);                                               \
     })
 
 #define get_token(tok, ttype, priv_type) \

--- a/parser.c
+++ b/parser.c
@@ -84,8 +84,8 @@ static Ast *ast_double(double val)
 
 char *make_label(void)
 {
-    String *s = make_string();
-    string_appendf(s, ".L%d", labelseq++);
+    String s = make_string();
+    string_appendf(&s, ".L%d", labelseq++);
     return get_cstring(s);
 }
 
@@ -766,8 +766,8 @@ static Ctype *read_union_def(void)
         return ctype;
     Dict *fields = read_struct_union_fields();
     int maxsize = 0;
-    for (Iter *i = list_iter(dict_values(fields)); !iter_end(i);) {
-        Ctype *fieldtype = iter_next(i);
+    for (Iter i = list_iter(dict_values(fields)); !iter_end(i);) {
+        Ctype *fieldtype = iter_next(&i);
         maxsize = (maxsize < fieldtype->size) ? fieldtype->size : maxsize;
     }
     Ctype *r = make_struct_type(fields, maxsize);
@@ -784,8 +784,8 @@ static Ctype *read_struct_def(void)
         return ctype;
     Dict *fields = read_struct_union_fields();
     int offset = 0;
-    for (Iter *i = list_iter(dict_values(fields)); !iter_end(i);) {
-        Ctype *fieldtype = iter_next(i);
+    for (Iter i = list_iter(dict_values(fields)); !iter_end(i);) {
+        Ctype *fieldtype = iter_next(&i);
         int size = (fieldtype->size < MAX_ALIGN) ? fieldtype->size : MAX_ALIGN;
         if (offset % size != 0)
             offset += size - offset % size;

--- a/parser.c
+++ b/parser.c
@@ -36,7 +36,7 @@ static Ast *read_decl_or_stmt(void);
 static Ctype *result_type(char op, Ctype *a, Ctype *b);
 static Ctype *convert_array(Ctype *ctype);
 static Ast *read_stmt(void);
-static Ctype *read_decl_int(Token **name);
+static Ctype *read_decl_int(Token *name);
 
 static Ast *ast_uop(int type, Ctype *ctype, Ast *operand)
 {
@@ -292,17 +292,17 @@ static void ensure_lvalue(Ast *ast)
 
 static void expect(char punct)
 {
-    Token *tok = read_token();
+    Token tok = read_token();
     if (!is_punct(tok, punct))
         error("'%c' expected, but got %s", punct, token_to_string(tok));
 }
 
-static bool is_ident(Token *tok, char *s)
+static bool is_ident(const Token tok, char *s)
 {
     return get_ttype(tok) == TTYPE_IDENT && !strcmp(get_ident(tok), s);
 }
 
-static bool is_right_assoc(Token *tok)
+static bool is_right_assoc(const Token tok)
 {
     return get_punct(tok) == '=';
 }
@@ -332,7 +332,7 @@ static int eval_intexpr(Ast *ast)
     }
 }
 
-static int priority(Token *tok)
+static int priority(const Token tok)
 {
     switch (get_punct(tok)) {
     case '[':
@@ -377,7 +377,7 @@ static Ast *read_func_args(char *fname)
 {
     List *args = make_list();
     while (1) {
-        Token *tok = read_token();
+        Token tok = read_token();
         if (is_punct(tok, ')'))
             break;
         unget_token(tok);
@@ -395,7 +395,7 @@ static Ast *read_func_args(char *fname)
 
 static Ast *read_ident_or_func(char *name)
 {
-    Token *tok = read_token();
+    Token tok = read_token();
     if (is_punct(tok, '('))
         return read_func_args(name);
     unget_token(tok);
@@ -437,10 +437,10 @@ static bool is_float_token(char *p)
 
 static Ast *read_prim(void)
 {
-    Token *tok = read_token();
-    if (!tok)
-        return NULL;
+    Token tok = read_token();
     switch (get_ttype(tok)) {
+    case TTYPE_NULL:
+        return NULL;
     case TTYPE_IDENT:
         return read_ident_or_func(get_ident(tok));
     case TTYPE_NUMBER: {
@@ -570,7 +570,7 @@ static Ctype *result_type(char op, Ctype *a, Ctype *b)
 
 static Ast *read_unary_expr(void)
 {
-    Token *tok = read_token();
+    Token tok = read_token();
     if (get_ttype(tok) != TTYPE_PUNCT) {
         unget_token(tok);
         return read_prim();
@@ -615,7 +615,7 @@ static Ast *read_struct_field(Ast *struc)
 {
     if (struc->ctype->type != CTYPE_STRUCT)
         error("struct expected, but got %s", ast_to_string(struc));
-    Token *name = read_token();
+    Token name = read_token();
     if (get_ttype(name) != TTYPE_IDENT)
         error("field name expected, but got %s", token_to_string(name));
     char *ident = get_ident(name);
@@ -629,7 +629,7 @@ static Ast *read_expr_int(int prec)
     if (!ast)
         return NULL;
     while (1) {
-        Token *tok = read_token();
+        Token tok = read_token();
         if (get_ttype(tok) != TTYPE_PUNCT) {
             unget_token(tok);
             return ast;
@@ -684,14 +684,11 @@ static Ast *read_expr(void)
     return read_expr_int(MAX_OP_PRIO);
 }
 
-static Ctype *get_ctype(Token *tok)
+static Ctype *get_ctype(const Token tok)
 {
-    char *ident;
-    if (!tok)
-        return NULL;
     if (get_ttype(tok) != TTYPE_IDENT)
         return NULL;
-    ident = get_ident(tok);
+    char *ident = get_ident(tok);
     if (!strcmp(ident, "void"))
         return ctype_void;
     if (!strcmp(ident, "int"))
@@ -707,14 +704,14 @@ static Ctype *get_ctype(Token *tok)
     return NULL;
 }
 
-static bool is_type_keyword(Token *tok)
+static bool is_type_keyword(const Token tok)
 {
     return get_ctype(tok) || is_ident(tok, "struct") || is_ident(tok, "union");
 }
 
 static Ast *read_decl_array_init_int(Ctype *ctype)
 {
-    Token *tok = read_token();
+    Token tok = read_token();
     if (ctype->ptr->type == CTYPE_CHAR && get_ttype(tok) == TTYPE_STRING)
         return ast_string(get_strtok(tok));
     if (!is_punct(tok, '{'))
@@ -722,7 +719,7 @@ static Ast *read_decl_array_init_int(Ctype *ctype)
               ctype_to_string(ctype), token_to_string(tok));
     List *initlist = make_list();
     while (1) {
-        Token *tok = read_token();
+        Token tok = read_token();
         if (is_punct(tok, '}'))
             break;
         unget_token(tok);
@@ -738,7 +735,7 @@ static Ast *read_decl_array_init_int(Ctype *ctype)
 
 static char *read_struct_union_tag(void)
 {
-    Token *tok = read_token();
+    Token tok = read_token();
     if (get_ttype(tok) == TTYPE_IDENT)
         return get_ident(tok);
     unget_token(tok);
@@ -752,7 +749,7 @@ static Dict *read_struct_union_fields(void)
     while (1) {
         if (!is_type_keyword(peek_token()))
             break;
-        Token *name;
+        Token name;
         Ctype *fieldtype = read_decl_int(&name);
         dict_put(r, get_ident(name), make_struct_field_type(fieldtype, 0));
         expect(';');
@@ -803,7 +800,7 @@ static Ctype *read_struct_def(void)
 
 static Ctype *read_decl_spec(void)
 {
-    Token *tok = read_token();
+    Token tok = read_token();
     Ctype *ctype =
         is_ident(tok, "struct")
             ? read_struct_def()
@@ -845,7 +842,7 @@ static Ast *read_decl_init_val(Ast *var)
 
 static Ctype *read_array_dimensions_int(Ctype *basetype)
 {
-    Token *tok = read_token();
+    Token tok = read_token();
     if (!is_punct(tok, '[')) {
         unget_token(tok);
         return NULL;
@@ -873,7 +870,7 @@ static Ctype *read_array_dimensions(Ctype *basetype)
 
 static Ast *read_decl_init(Ast *var)
 {
-    Token *tok = read_token();
+    Token tok = read_token();
     if (is_punct(tok, '='))
         return read_decl_init_val(var);
     if (var->ctype->len == -1)
@@ -883,7 +880,7 @@ static Ast *read_decl_init(Ast *var)
     return ast_decl(var, NULL);
 }
 
-static Ctype *read_decl_int(Token **name)
+static Ctype *read_decl_int(Token *name)
 {
     Ctype *ctype = read_decl_spec();
     *name = read_token();
@@ -894,7 +891,7 @@ static Ctype *read_decl_int(Token **name)
 
 static Ast *read_decl(void)
 {
-    Token *varname;
+    Token varname;
     Ctype *ctype = read_decl_int(&varname);
     if (ctype == ctype_void)
         error("Storage size of '%s' is not known", token_to_string(varname));
@@ -908,9 +905,8 @@ static Ast *read_if_stmt(void)
     Ast *cond = read_expr();
     expect(')');
     Ast *then = read_stmt();
-    Token *tok = read_token();
-    if (!tok || get_ttype(tok) != TTYPE_IDENT ||
-        strcmp(get_ident(tok), "else")) {
+    Token tok = read_token();
+    if (get_ttype(tok) != TTYPE_IDENT || strcmp(get_ident(tok), "else")) {
         unget_token(tok);
         return ast_if(cond, then, NULL);
     }
@@ -920,7 +916,7 @@ static Ast *read_if_stmt(void)
 
 static Ast *read_opt_decl_or_stmt(void)
 {
-    Token *tok = read_token();
+    Token tok = read_token();
     if (is_punct(tok, ';'))
         return NULL;
     unget_token(tok);
@@ -929,7 +925,7 @@ static Ast *read_opt_decl_or_stmt(void)
 
 static Ast *read_opt_expr(void)
 {
-    Token *tok = read_token();
+    Token tok = read_token();
     if (is_punct(tok, ';'))
         return NULL;
     unget_token(tok);
@@ -960,7 +956,7 @@ static Ast *read_return_stmt(void)
 
 static Ast *read_stmt(void)
 {
-    Token *tok = read_token();
+    Token tok = read_token();
     if (is_ident(tok, "if"))
         return read_if_stmt();
     if (is_ident(tok, "for"))
@@ -977,8 +973,8 @@ static Ast *read_stmt(void)
 
 static Ast *read_decl_or_stmt(void)
 {
-    Token *tok = peek_token();
-    if (!tok)
+    Token tok = peek_token();
+    if (get_ttype(tok) == TTYPE_NULL)
         return NULL;
     return is_type_keyword(tok) ? read_decl() : read_stmt();
 }
@@ -993,7 +989,7 @@ static Ast *read_compound_stmt(void)
             list_push(list, stmt);
         if (!stmt)
             break;
-        Token *tok = read_token();
+        Token tok = read_token();
         if (is_punct(tok, '}'))
             break;
         unget_token(tok);
@@ -1005,20 +1001,20 @@ static Ast *read_compound_stmt(void)
 static List *read_params(void)
 {
     List *params = make_list();
-    Token *tok = read_token();
+    Token tok = read_token();
     if (is_punct(tok, ')'))
         return params;
     unget_token(tok);
     while (1) {
         Ctype *ctype = read_decl_spec();
-        Token *pname = read_token();
+        Token pname = read_token();
         if (get_ttype(pname) != TTYPE_IDENT)
             error("Identifier expected, but got %s", token_to_string(pname));
         ctype = read_array_dimensions(ctype);
         if (ctype->type == CTYPE_ARRAY)
             ctype = make_ptr_type(ctype->ptr);
         list_push(params, ast_lvar(ctype, get_ident(pname)));
-        Token *tok = read_token();
+        Token tok = read_token();
         if (is_punct(tok, ')'))
             return params;
         if (!is_punct(tok, ','))
@@ -1043,11 +1039,11 @@ static Ast *read_func_def(Ctype *rettype, char *fname)
 
 static Ast *read_decl_or_func_def(void)
 {
-    Token *tok = peek_token();
-    if (!tok)
+    Token tok = peek_token();
+    if (get_ttype(tok) == TTYPE_NULL)
         return NULL;
     Ctype *ctype = read_decl_spec();
-    Token *name = read_token();
+    Token name = read_token();
     char *ident;
     if (get_ttype(name) != TTYPE_IDENT)
         error("Identifier expected, but got %s", token_to_string(name));

--- a/util.h
+++ b/util.h
@@ -13,14 +13,15 @@ typedef struct {
 
 #define INIT_SIZE 8
 
-static inline String *make_string(void)
+static inline String make_string(void)
 {
-    String *r = malloc(sizeof(String));
-    r->body = malloc(INIT_SIZE);
-    r->nalloc = INIT_SIZE;
-    r->len = 0;
-    r->body[0] = '\0';
-    return r;
+    char *body = malloc(INIT_SIZE);
+    body[0] = '\0';
+    return (String){
+        .body = body,
+        .nalloc = INIT_SIZE,
+        .len = 0,
+    };
 }
 
 static inline void realloc_body(String *s)
@@ -31,11 +32,9 @@ static inline void realloc_body(String *s)
     s->nalloc = newsize;
 }
 
-static inline char *get_cstring(String *s)
+static inline char *get_cstring(const String s)
 {
-    char *ret = s->body;
-    free(s);
-    return ret;
+    return s.body;
 }
 
 static inline void string_append(String *s, char c)
@@ -84,14 +83,14 @@ static inline void errorf(char *file, int line, char *fmt, ...)
 
 static inline char *quote_cstring(char *p)
 {
-    String *s = make_string();
+    String s = make_string();
     for (; *p; p++) {
         if (*p == '\"' || *p == '\\')
-            string_appendf(s, "\\%c", *p);
+            string_appendf(&s, "\\%c", *p);
         else if (*p == '\n')
-            string_appendf(s, "\\n");
+            string_appendf(&s, "\\n");
         else
-            string_append(s, *p);
+            string_append(&s, *p);
     }
     return get_cstring(s);
 }

--- a/util.h
+++ b/util.h
@@ -5,11 +5,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "list.h"
 
 typedef struct {
     char *body;
     int nalloc, len;
 } String;
+
+static List *cstrings = &EMPTY_LIST;
 
 #define INIT_SIZE 8
 
@@ -17,6 +20,7 @@ static inline String make_string(void)
 {
     char *body = malloc(INIT_SIZE);
     body[0] = '\0';
+    list_push(cstrings, body);
     return (String){
         .body = body,
         .nalloc = INIT_SIZE,

--- a/util.h
+++ b/util.h
@@ -18,8 +18,7 @@ static List *cstrings = &EMPTY_LIST;
 
 static inline String make_string(void)
 {
-    char *body = malloc(INIT_SIZE);
-    body[0] = '\0';
+    char *body = calloc(1, INIT_SIZE);
     list_push(cstrings, body);
     return (String){
         .body = body,

--- a/util.h
+++ b/util.h
@@ -26,15 +26,16 @@ static inline String *make_string(void)
 static inline void realloc_body(String *s)
 {
     int newsize = s->nalloc * 2;
-    char *body = malloc(newsize);
-    strcpy(body, s->body);
+    char *body = realloc(s->body, newsize);
     s->body = body;
     s->nalloc = newsize;
 }
 
 static inline char *get_cstring(String *s)
 {
-    return s->body;
+    char *ret = s->body;
+    free(s);
+    return ret;
 }
 
 static inline void string_append(String *s, char c)

--- a/verbose.c
+++ b/verbose.c
@@ -210,12 +210,13 @@ char *ast_to_string(Ast *ast)
     return get_cstring(s);
 }
 
-char *token_to_string(Token *tok)
+char *token_to_string(const Token tok)
 {
-    if (!tok)
+    enum TokenType ttype = get_ttype(tok);
+    if (ttype == TTYPE_NULL)
         return "(null)";
     String *s = make_string();
-    switch (get_ttype(tok)) {
+    switch (ttype) {
     case TTYPE_IDENT:
         return get_ident(tok);
     case TTYPE_PUNCT:
@@ -232,7 +233,8 @@ char *token_to_string(Token *tok)
     case TTYPE_STRING:
         string_appendf(s, "\"%s\"", get_strtok(tok));
         return get_cstring(s);
+    default:
+        error("internal error: unknown token type: %d", get_ttype(tok));
     }
-    error("internal error: unknown token type: %d", get_ttype(tok));
     return NULL; /* non-reachable */
 }


### PR DESCRIPTION
I let token lie on stack instead of heap, since I think we don't need token live too long.