### PR TITLE
Fix incorrect test for pointer arithmetic

### DIFF
--- a/tests/pointer_arith.c
+++ b/tests/pointer_arith.c
@@ -38,7 +38,7 @@ int t4()
     char *s = "abcdefghi";
     void *x = s;
     char *t = x + 1;
-    expect(105, *t);
+    expect(98, *t);
 }
 
 int main()


### PR DESCRIPTION
I am sorry that the final commit of  "parse void function" has an error in test set.  