### PR TITLE
Let gcc optimizatioin flag be accepted, fix #14

### DIFF
--- a/codegen_x64.c
+++ b/codegen_x64.c
@@ -301,7 +301,7 @@ static void emit_comp(char *inst, Ast *ast)
 static void emit_binop_int_arith(Ast *ast)
 {
     SAVE;
-    char *op;
+    char *op = NULL;
     switch (ast->type) {
     case '+':
         op = "add";
@@ -732,8 +732,8 @@ void emit_data_section(void)
         char *label = make_label();
         v->flabel = label;
         emit_label("%s:", label);
-        emit(".long %d", ((int *) &v->fval)[0]);
-        emit(".long %d", ((int *) &v->fval)[1]);
+        emit(".long %d", v->lval[0]);
+        emit(".long %d", v->lval[1]);
     }
 }
 

--- a/mzcc.h
+++ b/mzcc.h
@@ -79,7 +79,10 @@ typedef struct __Ast {
 
         /* float or double */
         struct {
-            double fval;
+            union {
+                double fval;
+                int lval[2];
+            };
             char *flabel;
         };
 


### PR DESCRIPTION
After this revision, MazuCC could be compiled by my gcc (version 7.4.0) with -O3 or -O2.