### PR TITLE
Fix output file not initialized when -o omitted

### DIFF
--- a/main.c
+++ b/main.c
@@ -65,9 +65,13 @@ static void parse_args(int argc, char **argv)
 
 static void open_output_file()
 {
-    if (outfile && !(outfp = fopen(outfile, "w"))) {
-        printf("Can not open file %s\n", outfile);
-        exit(1);
+    if (outfile) {
+        if (!(outfp = fopen(outfile, "w"))) {
+            printf("Can not open file %s\n", outfile);
+            exit(1);
+        }
+    } else {
+        outfp = stdout;
     }
 }
 


### PR DESCRIPTION
MazuCC segfaults if option -o is omitted:
```bash
$ ./mzcc sample/nqueen.c
Segmentation fault
```
This issue was introduced in PR #19 when the -o option was added. I don't know if MazuCC is still supposed to output to stdout in case of no output specified, but if so, this PR fixes this by checking if the output file was set or not, and if not, sets stdout as the output file.