### PR TITLE
Fix wrong shifts on integer expressions

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -327,9 +327,9 @@ static int eval_intexpr(Ast *ast)
     case '/':
         return eval_intexpr(ast->left) / eval_intexpr(ast->right);
     case PUNCT_LSHIFT:
-        return eval_intexpr(ast->left) >> eval_intexpr(ast->right);
-    case PUNCT_RSHIFT:
         return eval_intexpr(ast->left) << eval_intexpr(ast->right);
+    case PUNCT_RSHIFT:
+        return eval_intexpr(ast->left) >> eval_intexpr(ast->right);
     default:
         error("Integer expression expected, but got %s", ast_to_string(ast));
         return 0; /* non-reachable */


### PR DESCRIPTION
MazuCC produces wrong shifts (i.e: inverted) on integer expressions.
Steps to reproduce:
```bash
$ echo "int foo = 16<<2; int bar = 16>>2;" > test.c
$ ./mzcc test.c
        .data                # emit_data_section:724
.global foo                  # emit_global_var -> emit_data:694
foo:                         # emit_global_var -> emit_data:695                 
        .long 4              # emit_global_var -> emit_data -> emit_data_int:681
.global bar                  # emit_global_var -> emit_data:694                 
bar:                         # emit_global_var -> emit_data:695                 
        .long 64             # emit_global_var -> emit_data -> emit_data_int:681
```
FIx this by inverting the shifts order (left -> right / right -> left) on parser.